### PR TITLE
Minor updates for Go niceties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,7 @@ jobs:
 
       - name: "Check: Gofmt"
         run: scripts/check_gofmt.sh
+
+      - name: "Generate README.md"
+        run: OUT=$(go run main.go) && echo "$OUT" > ../README.md
+        working-directory: ./updater

--- a/updater/.golangci.yml
+++ b/updater/.golangci.yml
@@ -1,0 +1,60 @@
+linters:
+  disable:
+    # obnoxious
+    - cyclop
+    - dupl
+    - exhaustruct
+    - exhaustivestruct
+    - forcetypeassert
+    - funlen
+    - gochecknoinits
+    - gochecknoglobals
+    - gocognit
+    - gocyclo
+    - godox
+    - gomnd
+    - nlreturn
+    - paralleltest
+    - testpackage
+    - wsl
+    - varnamelen
+
+    # buggy
+    - execinquery
+    - thelper
+
+    # deprecated
+    - deadcode
+    - golint
+    - ifshort
+    - interfacer
+    - maligned
+    - nosnakecase
+    - scopelint
+    - structcheck
+    - varcheck
+  enable-all: true
+
+linters-settings:
+  forbidigo:
+    forbid:
+      - '^errors\.Wrap$'
+      - '^errors\.Wrapf$'
+      - '^fmt\.Errorf$'
+  gci:
+    sections:
+      - Standard
+      - Default
+      - Prefix(github.com/brandur)
+
+  gocritic:
+    disabled-checks:
+      - commentFormatting
+
+  gosec:
+    excludes:
+      - G203
+
+  wrapcheck:
+    ignorePackageGlobs:
+      - github.com/brandur/*

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -1,3 +1,8 @@
 module github.com/brandur/brandur/updater
 
 go 1.15
+
+require (
+	golang.org/x/sync v0.1.0
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
+)

--- a/updater/go.sum
+++ b/updater/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=


### PR DESCRIPTION
A grab bucket:

* Switch to `errgroup` over home-grown waitgroup-based parallelism.
* Add a real `golangci-lint` configuration so we're running some lints.
* Threqd contexts through to HTTP requests.
* Use `xerrors` for error wrapping (for back traces).