### PR TITLE
Upgrade to Go 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: brandur CI
 
-env:
-  GO_VERSION: 1.19
-
 on:
   pull_request:
   push:
@@ -20,13 +17,16 @@ jobs:
     timeout-minutes: 3
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
+          cache: true
+          cache-dependency-path: "updater/go.sum"
+          check-latest: true
+          go-version-file: "updater/go.mod"
 
       - name: "Generate README.md"
         run: OUT=$(go run main.go) && echo "$OUT" > ../README.md
@@ -46,32 +46,38 @@ jobs:
     timeout-minutes: 3
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
+          cache: true
+          cache-dependency-path: "updater/go.sum"
+          check-latest: true
+          go-version-file: "updater/go.mod"
 
       - name: "Check: golangci-lint"
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: ./updater
-          version: v1.49
+          version: v1.54
 
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
+          cache: true
+          cache-dependency-path: "updater/go.sum"
+          check-latest: true
+          go-version-file: "updater/go.mod"
 
       - name: Debug
         run: |

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -1,6 +1,6 @@
 module github.com/brandur/brandur/updater
 
-go 1.15
+go 1.21
 
 require (
 	golang.org/x/sync v0.1.0

--- a/updater/main.go
+++ b/updater/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -174,7 +174,7 @@ func getURLData(ctx context.Context, url string) (*http.Response, []byte, error)
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("error reading response body from URL '%s': %w", url, err)
 	}


### PR DESCRIPTION
Upgrade to Go 1.21, move CI over to respect Go version from `go.mod`
instead of hard-coding it separately. Upgrade golangci-lint to 1.54.