### PR TITLE
Upgrade Go to 1.24 + golangci-lint 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
           go-version-file: "updater/go.mod"
 
       - name: "Check: golangci-lint"
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
           working-directory: ./updater
-          version: v1.54
+          version: v2.0.0
 
   tests:
     runs-on: ubuntu-latest

--- a/updater/.golangci.yml
+++ b/updater/.golangci.yml
@@ -1,60 +1,66 @@
+version: "2"
+
 linters:
+  default: all
+
   disable:
     # obnoxious
     - cyclop
+    - depguard
     - dupl
     - exhaustruct
-    - exhaustivestruct
     - forcetypeassert
     - funlen
-    - gochecknoinits
     - gochecknoglobals
+    - gochecknoinits
     - gocognit
+    - goconst
     - gocyclo
     - godox
-    - gomnd
+    - lll
+    - mnd
     - nlreturn
     - paralleltest
     - testpackage
-    - wsl
     - varnamelen
+    - wsl
 
-    # buggy
-    - execinquery
-    - thelper
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: ^errors\.Wrap$
+        - pattern: ^errors\.Wrapf$
+        - pattern: ^fmt\.Errorf$
 
-    # deprecated
-    - deadcode
-    - golint
-    - ifshort
-    - interfacer
-    - maligned
-    - nosnakecase
-    - scopelint
-    - structcheck
-    - varcheck
-  enable-all: true
+    gocritic:
+      disabled-checks:
+        - commentFormatting
 
-linters-settings:
-  forbidigo:
-    forbid:
-      - '^errors\.Wrap$'
-      - '^errors\.Wrapf$'
-      - '^fmt\.Errorf$'
-  gci:
-    sections:
-      - Standard
-      - Default
-      - Prefix(github.com/brandur)
+    gosec:
+      excludes:
+        - G203
 
-  gocritic:
-    disabled-checks:
-      - commentFormatting
+    wrapcheck:
+      ignore-package-globs:
+        - github.com/brandur/*
 
-  gosec:
-    excludes:
-      - G203
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
 
-  wrapcheck:
-    ignorePackageGlobs:
-      - github.com/brandur/*
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - Standard
+        - Default
+        - Prefix(github.com/brandur)

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -1,8 +1,8 @@
 module github.com/brandur/brandur/updater
 
-go 1.21
+go 1.24
 
 require (
 	golang.org/x/sync v0.1.0
-	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 )


### PR DESCRIPTION
Take us up a few major versions from Go 1.21 to 1.24 and golangci-lint
v1 to v2.
